### PR TITLE
changes

### DIFF
--- a/mario-demo/include/st7735/ST7735_TFT_graphics.hpp
+++ b/mario-demo/include/st7735/ST7735_TFT_graphics.hpp
@@ -120,7 +120,7 @@ public:
 	Display_Return_Codes_e TFTdrawBitmap(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t color, uint16_t bgcolor, uint8_t *pBmp, uint16_t sizeOfBitmap);
 	Display_Return_Codes_e TFTdrawBitmap24Data(uint8_t x, uint8_t y, uint8_t *pBmp, uint8_t w, uint8_t h);
 	Display_Return_Codes_e TFTdrawBitmap16Data(uint8_t x, uint8_t y, uint8_t *pBmp, uint8_t w, uint8_t h);
-	Display_Return_Codes_e TFTdrawSpriteData(uint8_t x, uint8_t y, uint8_t *pBmp, uint8_t w, uint8_t h, uint16_t backgroundColor);
+	Display_Return_Codes_e TFTdrawSpriteData(uint8_t x, uint8_t y, uint8_t *pBmp, uint8_t w, uint8_t h, uint16_t backgroundColor, bool SpriteOrTile);
 
 protected:
 	void pushColor(uint16_t color);

--- a/mario-demo/mario-demo.cpp
+++ b/mario-demo/mario-demo.cpp
@@ -223,6 +223,8 @@ void main2() {
 
 int main() {
     stdio_init_all(); // Initialize chosen serial port
+    sleep_ms(500);
+    printf("Start\r\n");
 	gpio_init(BTN_1);
     gpio_set_dir(BTN_1, GPIO_IN);
 	gpio_init(BTN_2);
@@ -231,6 +233,11 @@ int main() {
     gpio_set_dir(BTN_3, GPIO_IN);
 	gpio_init(BTN_4);
     gpio_set_dir(BTN_4, GPIO_IN);
+
+    gpio_pull_down(BTN_1);
+    gpio_pull_down(BTN_2);
+    gpio_pull_down(BTN_3);
+    gpio_pull_down(BTN_4);
 
     //*************** USER OPTION 0 SPI_SPEED + TYPE ***********
 	bool bhardwareSPI = false; // true for hardware spi,
@@ -260,9 +267,9 @@ int main() {
 
 	// ****** USER OPTION 2 Screen Setup ******
 	uint8_t OFFSET_COL = 0;	   // 2, These offsets can be adjusted for any issues->
-	uint8_t OFFSET_ROW = -16;	   // 3, with manufacture tolerance/defects
+	uint8_t OFFSET_ROW = 0;	   // 3, with manufacture tolerance/defects
 	uint16_t TFT_WIDTH = 128;  // Screen width in pixels
-	uint16_t TFT_HEIGHT = 192; // Screen height in pixels
+	uint16_t TFT_HEIGHT = 160; // Screen height in pixels
 	myTFT.TFTInitScreenSize(OFFSET_COL, OFFSET_ROW, TFT_WIDTH, TFT_HEIGHT);
 	// ******************************************
 
@@ -309,7 +316,7 @@ int main() {
 
     //myTFT.TFTdrawBitmap16Data(0, 0, (uint8_t *)pSuperMarioWorldTitle, 128, 160);
     myTFT.TFTsetRotation(myTFT.TFT_Degrees_270);
-    myTFT.TFTdrawBitmap16Data(16, 0, (uint8_t *)pSuperMarioWorldTitle, 160, 128);
+    myTFT.TFTdrawBitmap16Data(0, 0, (uint8_t *)pSuperMarioWorldTitle, 160, 128);
     myTFT.TFTdrawText(37, 80, teststr1, ST7735_WHITE, BACKGR, 1);
     myTFT.TFTdrawText(37, 90, teststr2, ST7735_WHITE, BACKGR, 1);
     myTFT.TFTdrawText(37, 100, teststr3, ST7735_WHITE, BACKGR, 1);
@@ -447,39 +454,39 @@ int main() {
                 xdk = xd2 + km;
                 
                 // Only draw tiles that are visible on screen (0-160 horizontal range)
-                if (xdk >= -16 && xdk < 176) {
+                if (xdk >= 0 && xdk < 160) {
                     if (map[j][k] == 0) {
                         myTFT.TFTfillRect(xdk, jm, 16, 16, BACKGR);
                     } else if (map[j][k] == 10) {
-                        myTFT.TFTdrawBitmap16Data(xdk, jm, (uint8_t *)pDirt, 16, 16);
+                        myTFT.TFTdrawSpriteData(xdk, jm, (uint8_t *)pDirt, 16, 16, BACKGR , false);
                     } else if (map[j][k] == 11) {
-                        myTFT.TFTdrawBitmap16Data(xdk, jm, (uint8_t *)pGrass, 16, 16);
+                        myTFT.TFTdrawSpriteData(xdk, jm, (uint8_t *)pGrass, 16, 16,BACKGR , false);
                     } else if (map[j][k] == 12) {
-                        myTFT.TFTdrawBitmap16Data(xdk, jm, (uint8_t *)pWoodBlock, 16, 16);
+                        myTFT.TFTdrawSpriteData(xdk, jm, (uint8_t *)pWoodBlock, 16, 16, BACKGR , false);
                     } else if (map[j][k] == 20) {
-                        myTFT.TFTdrawBitmap16Data(xdk, jm, (uint8_t *)pRoBlock1, 16, 16);
+                        myTFT.TFTdrawSpriteData(xdk, jm, (uint8_t *)pRoBlock1, 16, 16, BACKGR , false);
                     } else if (map[j][k] == 21) {
-                        myTFT.TFTdrawBitmap16Data(xdk, jm, (uint8_t *)pLuckBlock1, 16, 16);
+                        myTFT.TFTdrawSpriteData(xdk, jm, (uint8_t *)pLuckBlock1, 16, 16, BACKGR , false);
                     } else if (map[j][k] == 30) {
-                        myTFT.TFTdrawBitmap16Data(xdk, jm, (uint8_t *)pPipeL, 16, 16);
+                        myTFT.TFTdrawSpriteData(xdk, jm, (uint8_t *)pPipeL, 16, 16, BACKGR , false);
                     } else if (map[j][k] == 31) {
-                        myTFT.TFTdrawBitmap16Data(xdk, jm, (uint8_t *)pPipeR, 16, 16);
+                        myTFT.TFTdrawSpriteData(xdk, jm, (uint8_t *)pPipeR, 16, 16, BACKGR , false);
                     } else if (map[j][k] == 32) {
-                        myTFT.TFTdrawBitmap16Data(xdk, jm, (uint8_t *)pPipeTL, 16, 16);
+                        myTFT.TFTdrawSpriteData(xdk, jm, (uint8_t *)pPipeTL, 16, 16, BACKGR , false);
                     } else if (map[j][k] == 33) {
-                        myTFT.TFTdrawBitmap16Data(xdk, jm, (uint8_t *)pPipeTR, 16, 16);
+                        myTFT.TFTdrawSpriteData(xdk, jm, (uint8_t *)pPipeTR, 16, 16, BACKGR , false);
                     }
                 }
             }
         }
 
-        myTFT.TFTdrawSpriteData(xd2+68, 78, (uint8_t *)pKoopaIdle1, 16, 27, BACKGR);
-        myTFT.TFTdrawSpriteData(xd1, pos[1], (uint8_t *)Mario, 16, 24, BACKGR);
-        myTFT.TFTdrawText(20, 0, name, ST7735_WHITE, BACKGR, 1);
-        myTFT.TFTdrawText(20, 8, position, ST7735_WHITE, BACKGR, 1);
-        myTFT.TFTdrawText(94, 0, world, ST7735_WHITE, BACKGR, 1);
-        myTFT.TFTdrawText(142, 0, time, ST7735_WHITE, BACKGR, 1);
-        myTFT.TFTdrawText(142, 8, timer, ST7735_WHITE, BACKGR, 1);
+        myTFT.TFTdrawSpriteData(xd2+68, 78, (uint8_t *)pKoopaIdle1, 16, 27, BACKGR, true);
+        myTFT.TFTdrawSpriteData(xd1, pos[1], (uint8_t *)Mario, 16, 24, BACKGR, true);
+        myTFT.TFTdrawText(5, 0, name, ST7735_WHITE, BACKGR, 1);
+        myTFT.TFTdrawText(5, 8, position, ST7735_WHITE, BACKGR, 1);
+        myTFT.TFTdrawText(74, 0, world, ST7735_WHITE, BACKGR, 1);
+        myTFT.TFTdrawText(122, 0, time, ST7735_WHITE, BACKGR, 1);
+        myTFT.TFTdrawText(122, 8, timer, ST7735_WHITE, BACKGR, 1);
         TFT_MILLISEC_DELAY(10);
 
         //myTFT.TFTdrawBitmap16Data(y, xd1, (uint8_t *)Mario, 24, 16);

--- a/mario-demo/src/st7735/ST7735_TFT_graphics.cpp
+++ b/mario-demo/src/st7735/ST7735_TFT_graphics.cpp
@@ -998,7 +998,7 @@ Display_Return_Codes_e ST7735_TFT_graphics::TFTdrawBitmap16Data(uint8_t x, uint8
 	if ((x + w - 1) >= _widthTFT)
 		w = _widthTFT - x;
 	if ((y + h - 1) >= _heightTFT)
-		h = _heightTFT - y;
+		h = _heightTFT - y; 
 
 	// Process bitmap data row-by-row
 	for (j = 0; j < h; j++)
@@ -1414,13 +1414,14 @@ void ST7735_TFT_graphics::setTextColor(uint16_t c, uint16_t b)
 	@param w width of the sprite in pixels
 	@param h height of the sprite in pixels
 	@param backgroundColor the background color of sprite (16 bit 565) this will be made transparent
+	@param SpriteOrTile true the background color is ignored.if false it is printed.
 	@note Experimental , does not use buffer or malloc, just draw pixel
 	@return
 		-# Display_Success=success
 		-# Display_BitmapNullptr=invalid pointer object
 		-# Display_BitmapScreenBounds=Co-ordinates out of bounds
 */
-Display_Return_Codes_e  ST7735_TFT_graphics::TFTdrawSpriteData(uint8_t x, uint8_t y, uint8_t *pBmp, uint8_t w, uint8_t h, uint16_t backgroundColor)
+Display_Return_Codes_e  ST7735_TFT_graphics::TFTdrawSpriteData(uint8_t x, uint8_t y, uint8_t *pBmp, uint8_t w, uint8_t h, uint16_t backgroundColor, bool SpriteOrTile)
 {
 	uint8_t i, j;
 	uint16_t colour;
@@ -1430,16 +1431,17 @@ Display_Return_Codes_e  ST7735_TFT_graphics::TFTdrawSpriteData(uint8_t x, uint8_
 		printf("Error TFTdrawSprite 1: Sprite array is nullptr\r\n");
 		return Display_BitmapNullptr;
 	}
-	// Check bounds
-	if ((x >= _widthTFT) || (y >= _heightTFT))
-	{
-		printf("Error TFTdrawSprite 2: Sprite out of screen bounds\r\n");
-		return Display_BitmapScreenBounds;
-	}
-	if ((x + w - 1) >= _widthTFT)
-		w = _widthTFT - x;
-	if ((y + h - 1) >= _heightTFT)
-		h = _heightTFT - y;
+ 	/* Check bounds , commented out in branch changes 03-2025
+  	// if ((x >= _widthTFT) || (y >= _heightTFT))
+	// {
+	// 	printf("Error TFTdrawSprite 2: Sprite out of screen bounds\r\n");
+	// 	return Display_BitmapScreenBounds;
+	// } 
+	// if ((x + w - 1) >= _widthTFT)
+	// 	w = _widthTFT - x;
+	// if ((y + h - 1) >= _heightTFT)
+	// 	h = _heightTFT - y; 
+	*/
 
 	for(j = 0; j < h; j++)
 	{
@@ -1447,7 +1449,11 @@ Display_Return_Codes_e  ST7735_TFT_graphics::TFTdrawSpriteData(uint8_t x, uint8_
 		{
 			colour = (pBmp[0] << 8) | pBmp[1];
 			pBmp += 2;
-			if (colour != backgroundColor){
+			if(SpriteOrTile){
+				if (colour != backgroundColor){
+					TFTdrawPixel(x+i-1, y + j-1, colour);
+				}
+			}else{
 				TFTdrawPixel(x+i-1, y + j-1, colour);
 			}
 		}


### PR DESCRIPTION
Hi 

Firstly you do not need pull down resistors you can use the PICO on-board resistors  using gpio_pull_down();
I added these. 

Secondly I don't understand this , this is the wrong way to do this. 
`	uint8_t OFFSET_COL = 0;	   // 2, These offsets can be adjusted for any issues->
	uint8_t OFFSET_ROW = -16;	   // 3, with manufacture tolerance/defects
	uint16_t TFT_WIDTH = 128;  // Screen width in pixels
	uint16_t TFT_HEIGHT = 192; // Screen height in pixels`
So i reset everything to 0,0 offset. 

Thirdly when I ran software the terminal was flooded with errors. 
ST7735_TFT_PICO returns errors to serial terminal on 38000 baud. 
![1](https://github.com/user-attachments/assets/ef3757a0-f9c1-4ea8-9bf2-86f9280d56ac)
So i disabled all  boundary checking on the TFTdrawSpriteData() function by commenting it out.

Fourthly I added a new parameter to TFTdrawSpriteData() :  SpriteOrTile , if true draw sprite , if false draw tile. 
Its a bit slower as TFTdrawSpriteData draws pixel by pixel not row by row like TFTdrawBitmap16Data(). If that a problem you can try disabling boundary checking in TFTdrawBitmap16Data().
Boundary checking should work normally but i suspect your offsets calculation are inaccurate. 

It looks like its working now. 